### PR TITLE
뷰어 컴포넌트에 복사 버튼에 마우스 커서가 위치하면 색상을 강조하는 기능 추가

### DIFF
--- a/provider/app/global.css
+++ b/provider/app/global.css
@@ -2433,12 +2433,20 @@ p {
   order: 2;
 }
 
-.copy-button {
+.viewer-codeblock-copy-button {
   background: #d1a0ff;
-  color: white;
+  color: var(--white);
   border: none;
   border-radius: 3px;
   padding: 5px 10px;
   cursor: pointer;
   font-size: 12px;
+}
+
+.viewer-codeblock-copy-button:hover {
+  background: #b080ff;
+}
+
+.viewer-codeblock-copy-button:active {
+  background: #a060ff;
 }

--- a/provider/components/Viewer.jsx
+++ b/provider/components/Viewer.jsx
@@ -81,6 +81,7 @@ export default function Viewer({ content, height }) {
           },
         });
 
+        // 코드 블록에 복사 버튼 추가
         const preElements = document.querySelectorAll("pre");
         for (const codeBlock of preElements) {
           const code = codeBlock.querySelector("code");
@@ -88,14 +89,13 @@ export default function Viewer({ content, height }) {
           buttonWrapper.classList.add("flex-end");
           const button = document.createElement("button");
           button.innerText = "복사";
-          button.classList.add("copy-button");
+          button.classList.add("viewer-codeblock-copy-button");
 
           button.addEventListener("click", () => {
             copyToClipboard(code.innerText, button);
           });
 
           buttonWrapper.appendChild(button);
-          codeBlock.style.position = "relative";
           codeBlock.insertBefore(buttonWrapper, codeBlock.firstChild);
         }
       } catch (error) {
@@ -110,6 +110,7 @@ export default function Viewer({ content, height }) {
 
     viewerRef.current.viewerInstance.setMarkdown(content);
 
+    // 마크다운 변경 시 코드 블록에 복사 버튼 다시 추가
     const preElements = document.querySelectorAll("pre");
     for (const codeBlock of preElements) {
       const code = codeBlock.querySelector("code");
@@ -117,7 +118,7 @@ export default function Viewer({ content, height }) {
       buttonWrapper.classList.add("flex-end");
       const button = document.createElement("button");
       button.innerText = "복사";
-      button.classList.add("copy-button");
+      button.classList.add("viewer-codeblock-copy-button");
 
       button.addEventListener("click", () => {
         copyToClipboard(code.innerText, button);


### PR DESCRIPTION
- [X] 복사 버튼위에 마우스 커서를 갖다대면 배경색이 강조됨


|색상 강조 전|색상 강조 후(hover)|
|--|--|
|![image](https://github.com/Ludium-Official/ludium-world-front-end/assets/49608580/4c53fe46-cc57-48cf-a833-8670fb0fd224) | ![image](https://github.com/Ludium-Official/ludium-world-front-end/assets/49608580/921524e8-432d-4861-a4c6-0460fbeac53d) |